### PR TITLE
Fix Git repository discovery and add tests

### DIFF
--- a/internal/pkg/common/actor.go
+++ b/internal/pkg/common/actor.go
@@ -10,8 +10,9 @@ func NewGitActor() (*GitActor, error) {
 	repoPath := "."
 	path, err := FindGitRepoRoot(repoPath)
 	if err != nil {
-		repoPath = path
+		return nil, err
 	}
+	repoPath = path
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
 		return nil, err

--- a/internal/pkg/common/actor_test.go
+++ b/internal/pkg/common/actor_test.go
@@ -1,0 +1,85 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/plumbing/object"
+)
+
+func TestNewGitActorFindsRepositoryFromSubdir(t *testing.T) {
+	tempDir := t.TempDir()
+
+	repo, err := git.PlainInit(tempDir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("failed to get worktree: %v", err)
+	}
+
+	filePath := filepath.Join(tempDir, "README.md")
+	if err := os.WriteFile(filePath, []byte("hello world"), 0o644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	if _, err := wt.Add("README.md"); err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+
+	_, err = wt.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test User",
+			Email: "test@example.com",
+			When:  time.Now(),
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	nestedDir := filepath.Join(tempDir, "nested", "dir")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("failed to create nested directory: %v", err)
+	}
+
+	originalWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get working directory: %v", err)
+	}
+	defer func() {
+		if chdirErr := os.Chdir(originalWD); chdirErr != nil {
+			t.Fatalf("failed to restore working directory: %v", chdirErr)
+		}
+	}()
+
+	if err := os.Chdir(nestedDir); err != nil {
+		t.Fatalf("failed to change directory: %v", err)
+	}
+
+	actor, err := NewGitActor()
+	if err != nil {
+		t.Fatalf("NewGitActor returned an error: %v", err)
+	}
+
+	if actor.Worktree == nil {
+		t.Fatalf("expected worktree to be initialized")
+	}
+
+	defer actor.Commits.Close()
+
+	commit, err := actor.Commits.Next()
+	if err != nil {
+		t.Fatalf("expected to read commit: %v", err)
+	}
+
+	if !strings.HasPrefix(commit.Message, "initial commit") {
+		t.Fatalf("unexpected commit message: %q", commit.Message)
+	}
+}

--- a/internal/pkg/common/utils.go
+++ b/internal/pkg/common/utils.go
@@ -20,7 +20,10 @@ func TrimAll(str string) string {
 }
 
 func FindGitRepoRoot(startDir string) (string, error) {
-	dir := startDir
+	dir, err := filepath.Abs(startDir)
+	if err != nil {
+		return "", err
+	}
 	for {
 		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
 			return dir, nil


### PR DESCRIPTION
## Summary
- normalize repository discovery to use absolute paths and return clear errors when no repo is found
- update Git actor/observer to use the discovered root and tighten status handling defaults
- add regression test to ensure NewGitActor works from nested directories and adjust commit formatting helper

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c8639779d88330a44a0489e8134062