### PR TITLE
Handle SSH auth when pushing

### DIFF
--- a/internal/pkg/common/actor.go
+++ b/internal/pkg/common/actor.go
@@ -1,10 +1,27 @@
 package common
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/go-git/go-git/v6"
 	"github.com/go-git/go-git/v6/plumbing/object"
+	"github.com/go-git/go-git/v6/plumbing/transport"
+	gitssh "github.com/go-git/go-git/v6/plumbing/transport/ssh"
 	"iter"
 )
+
+var defaultSSHKeyFiles = []string{
+	"id_ed25519",
+	"id_rsa",
+	"id_ecdsa",
+	"id_dsa",
+	"id_xmss",
+}
+
+var userHomeDir = os.UserHomeDir
 
 func NewGitActor() (*GitActor, error) {
 	repoPath := "."
@@ -61,8 +78,34 @@ func (g *GitActor) Commit() {
 }
 
 func (g *GitActor) Push() {
-	if g.Err == nil {
-		g.Err = g.Repo.Push(&git.PushOptions{})
+	if g.Err != nil {
+		return
+	}
+
+	remoteName, remoteURL, err := g.pushTarget()
+	if err != nil {
+		g.Err = fmt.Errorf("resolve push target: %w", err)
+		return
+	}
+
+	auth, err := g.buildPushAuth(remoteName, remoteURL)
+	if err != nil {
+		g.Err = err
+		return
+	}
+
+	pushOptions := &git.PushOptions{
+		RemoteName: remoteName,
+		RemoteURL:  remoteURL,
+		Auth:       auth,
+	}
+
+	err = g.Repo.Push(pushOptions)
+	if errors.Is(err, git.NoErrAlreadyUpToDate) {
+		return
+	}
+	if err != nil {
+		g.Err = err
 	}
 }
 
@@ -78,4 +121,92 @@ func (g *GitActor) Next() iter.Seq2[string, func()] {
 			}
 		}
 	}
+}
+
+func (g *GitActor) pushTarget() (string, string, error) {
+	remoteName := git.DefaultRemoteName
+	remote, err := g.Repo.Remote(remoteName)
+	if err != nil {
+		if errors.Is(err, git.ErrRemoteNotFound) {
+			remotes, listErr := g.Repo.Remotes()
+			if listErr != nil {
+				return "", "", fmt.Errorf("list git remotes: %w", listErr)
+			}
+			if len(remotes) == 0 {
+				return "", "", errors.New("no git remotes configured")
+			}
+			remote = remotes[0]
+		} else {
+			return "", "", fmt.Errorf("load remote %q: %w", remoteName, err)
+		}
+	}
+
+	cfg := remote.Config()
+	if cfg == nil {
+		return "", "", fmt.Errorf("remote %q has no configuration", remoteName)
+	}
+	if len(cfg.URLs) == 0 {
+		return cfg.Name, "", fmt.Errorf("remote %q has no URLs", cfg.Name)
+	}
+
+	return cfg.Name, cfg.URLs[len(cfg.URLs)-1], nil
+}
+
+func (g *GitActor) buildPushAuth(remoteName, remoteURL string) (transport.AuthMethod, error) {
+	if remoteURL == "" {
+		return nil, nil
+	}
+
+	endpoint, err := transport.NewEndpoint(remoteURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse remote %q URL %q: %w", remoteName, remoteURL, err)
+	}
+
+	if endpoint.Protocol != "ssh" {
+		return nil, nil
+	}
+
+	user := endpoint.User
+	if user == "" {
+		user = gitssh.DefaultUsername
+	}
+
+	var errs []error
+	if auth, err := gitssh.NewSSHAgentAuth(user); err == nil {
+		return auth, nil
+	} else {
+		errs = append(errs, fmt.Errorf("ssh agent: %w", err))
+	}
+
+	homeDir, err := userHomeDir()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("resolve home directory: %w", err))
+	} else {
+		sshDir := filepath.Join(homeDir, ".ssh")
+		for _, candidate := range defaultSSHKeyFiles {
+			keyPath := filepath.Join(sshDir, candidate)
+			if info, statErr := os.Stat(keyPath); statErr != nil {
+				if os.IsNotExist(statErr) {
+					continue
+				}
+				errs = append(errs, fmt.Errorf("stat %s: %w", keyPath, statErr))
+				continue
+			} else if info.IsDir() {
+				continue
+			}
+
+			auth, keyErr := gitssh.NewPublicKeysFromFile(user, keyPath, "")
+			if keyErr != nil {
+				errs = append(errs, fmt.Errorf("load %s: %w", keyPath, keyErr))
+				continue
+			}
+			return auth, nil
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil, fmt.Errorf("no SSH authentication available for remote %q", remoteName)
+	}
+
+	return nil, fmt.Errorf("no SSH authentication available for remote %q: %w", remoteName, errors.Join(errs...))
 }

--- a/internal/pkg/common/actor_test.go
+++ b/internal/pkg/common/actor_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-git/go-git/v6"
+	"github.com/go-git/go-git/v6/config"
 	"github.com/go-git/go-git/v6/plumbing/object"
 )
 
@@ -83,3 +84,124 @@ func TestNewGitActorFindsRepositoryFromSubdir(t *testing.T) {
 		t.Fatalf("unexpected commit message: %q", commit.Message)
 	}
 }
+
+func TestGitActorPushTargetSelectsLastRemoteURL(t *testing.T) {
+	repoDir := t.TempDir()
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{"https://example.com/repo.git", "git@example.com:repo.git"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create remote: %v", err)
+	}
+
+	actor := &GitActor{Repo: repo}
+	name, url, err := actor.pushTarget()
+	if err != nil {
+		t.Fatalf("pushTarget returned error: %v", err)
+	}
+	if name != "origin" {
+		t.Fatalf("expected remote name origin, got %q", name)
+	}
+	if url != "git@example.com:repo.git" {
+		t.Fatalf("expected last remote URL to be git@example.com:repo.git, got %q", url)
+	}
+}
+
+func TestGitActorPushTargetFallsBackWhenOriginMissing(t *testing.T) {
+	repoDir := t.TempDir()
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	_, err = repo.CreateRemote(&config.RemoteConfig{
+		Name: "upstream",
+		URLs: []string{"git@example.com:repo.git"},
+	})
+	if err != nil {
+		t.Fatalf("failed to create remote: %v", err)
+	}
+
+	actor := &GitActor{Repo: repo}
+	name, url, err := actor.pushTarget()
+	if err != nil {
+		t.Fatalf("pushTarget returned error: %v", err)
+	}
+	if name != "upstream" {
+		t.Fatalf("expected fallback remote upstream, got %q", name)
+	}
+	if url != "git@example.com:repo.git" {
+		t.Fatalf("unexpected fallback remote URL %q", url)
+	}
+}
+
+func TestGitActorPushTargetErrorsWhenNoRemote(t *testing.T) {
+	repoDir := t.TempDir()
+	repo, err := git.PlainInit(repoDir, false)
+	if err != nil {
+		t.Fatalf("failed to init repo: %v", err)
+	}
+
+	actor := &GitActor{Repo: repo}
+	if _, _, err := actor.pushTarget(); err == nil {
+		t.Fatalf("expected error when no remotes are configured")
+	}
+}
+
+func TestGitActorBuildPushAuthSkipsNonSSH(t *testing.T) {
+	actor := &GitActor{}
+	auth, err := actor.buildPushAuth("origin", "https://example.com/repo.git")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if auth != nil {
+		t.Fatalf("expected nil auth for non-SSH remote, got %#v", auth)
+	}
+}
+
+func TestGitActorBuildPushAuthUsesSSHKeyFromHome(t *testing.T) {
+	sshHome := t.TempDir()
+	sshDir := filepath.Join(sshHome, ".ssh")
+	if err := os.MkdirAll(sshDir, 0o755); err != nil {
+		t.Fatalf("failed to create ssh directory: %v", err)
+	}
+
+	keyPath := filepath.Join(sshDir, "id_ed25519")
+	writeTestSSHKey(t, keyPath)
+
+	oldHome := userHomeDir
+	t.Cleanup(func() {
+		userHomeDir = oldHome
+	})
+	userHomeDir = func() (string, error) { return sshHome, nil }
+
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	actor := &GitActor{}
+	auth, err := actor.buildPushAuth("origin", "git@example.com:repo.git")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if auth == nil {
+		t.Fatalf("expected ssh auth to be returned")
+	}
+}
+
+func writeTestSSHKey(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(testPrivateKey), 0o600); err != nil {
+		t.Fatalf("failed to write ssh key: %v", err)
+	}
+}
+
+// testPrivateKey is a throwaway OpenSSH-formatted RSA key used for auth tests.
+const testPrivateKey = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAlwAAAAdzc2gtcnNhAAAAAwEAAQAAAIEAwnBgLxppmmIfo43n3z/Mj56HLT6XX0UloaNiPk3DSNVyUPvVeruhdfUizy2va+FT2ufiaTEPAUKNN+f6rYEu03omEKLBN8lHrh5pZFPVa59zQn+IoAj4b5tMgbERY9gn3gkH6PlgVzAccAM+nUiHBKx7cj+hPaO5sKZzW9RHtrcAAAIIxVb4X8VW+F8AAAAHc3NoLXJzYQAAAIEAwnBgLxppmmIfo43n3z/Mj56HLT6XX0UloaNiPk3DSNVyUPvVeruhdfUizy2va+FT2ufiaTEPAUKNN+f6rYEu03omEKLBN8lHrh5pZFPVa59zQn+IoAj4b5tMgbERY9gn3gkH6PlgVzAccAM+nUiHBKx7cj+hPaO5sKZzW9RHtrcAAAADAQABAAAAgDWXIXt6DScm6k962jC29duTtvAqczAn78JINNi1OCDH67UUY/dq5YqMYOa3UcUrGqCYDtgtVFRlkmSZRIcztsLJx75Vsc1DeM/JJhKHe/TmGRShN+46KqCgbPvqhqhe67QEucBZLjvFsh6HsDYaRSlghEfr/Sgznm/pePQ3NJEJAAAAQFEdyt0aGkuK/q/64ffJ6O8lK34qF8U2iYHonitxPQqRfhX+yesoHUSoB1rs7ugU8LtQ6d216HdtOBgmbdzcX4cAAABBAODhr99hlModptvY5hNSbUzp46F5Ya6KYbXOznT2+eu7dEWlydFiwJhap1fnJ6s1QKDERKPVf8SGTqdykSSHIQMAAABBAN1YRlM1pNI1ItOJxAezcbcQMtQv/XvZ2qlj9TN6ZGb1ejYoCpB6H6velFUiHd1yXinSsfZ8Pqlg060LdDeV8z0AAAARcm9vdEBlMGZjYmM1NDY2NGUBAg==
+-----END OPENSSH PRIVATE KEY-----
+`


### PR DESCRIPTION
## Summary
- add SSH-aware push handling that discovers the target remote, loads agent credentials or fallback keys, and surfaces clearer errors when no auth is available
- cover the new behavior with unit tests for remote selection and authentication helpers, including a fixture key for testing

## Testing
- go test ./...
- go test -race -covermode=atomic -shuffle=on -count=1 ./...
- golangci-lint run ./...


------
https://chatgpt.com/codex/tasks/task_e_68c88ba94e7883309b6a9bdce4a4880f